### PR TITLE
remove stacktrace calls from debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MarkdownAST.jl changelog
 
+## Version `v0.1.2`
+
+* ![Bugfix][badge-bugfix] The `getproperty` and `setproperty!` methods no longer print unnecessary debug log. ([#19][github-19])
+
 ## Version `v0.1.1`
 
 * ![Bugfix][badge-bugfix] `append!` and `prepend!` methods now correctly append nodes from a `node.children` iterator. ([#16][github-16])
@@ -10,6 +14,7 @@ Initial release.
 
 <!-- issue link definitions -->
 [github-16]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/16
+[github-19]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/19
 <!-- end of issue link definitions -->
 
 [markdownast]: https://github.com/JuliaDocs/MarkdownAST.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MarkdownAST"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 authors = ["Morten Piibeleht <morten.piibeleht@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MarkdownAST"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 authors = ["Morten Piibeleht <morten.piibeleht@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.2-dev"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/node.jl
+++ b/src/node.jl
@@ -115,7 +115,7 @@ function Base.getproperty(node::Node{T}, name::Symbol) where T
         getfield(node, :meta)
     else
         # TODO: error("type Node does not have property $(name)")
-        @debug "Accessing private field $(name) of Node" stacktrace()
+        @debug "Accessing private field $(name) of Node"
         getfield(node, name)
     end
 end
@@ -127,11 +127,11 @@ function Base.setproperty!(node::Node, name::Symbol, x)
         setfield!(node, :meta, x)
     elseif name in propertynames(node)
         # TODO: error("Unable to set property $(name) for Node")
-        @debug "Setting private field :$(name) of Node" stacktrace()
+        @debug "Setting private field :$(name) of Node"
         setfield!(node, name, x)
     else
         # TODO: error("type Node does not have property $(name)")
-        @debug "Accessing private field :$(name) of Node" stacktrace()
+        @debug "Accessing private field :$(name) of Node"
         setfield!(node, name, x)
     end
 end

--- a/src/node.jl
+++ b/src/node.jl
@@ -115,7 +115,6 @@ function Base.getproperty(node::Node{T}, name::Symbol) where T
         getfield(node, :meta)
     else
         # TODO: error("type Node does not have property $(name)")
-        @debug "Accessing private field $(name) of Node"
         getfield(node, name)
     end
 end
@@ -127,11 +126,9 @@ function Base.setproperty!(node::Node, name::Symbol, x)
         setfield!(node, :meta, x)
     elseif name in propertynames(node)
         # TODO: error("Unable to set property $(name) for Node")
-        @debug "Setting private field :$(name) of Node"
         setfield!(node, name, x)
     else
         # TODO: error("type Node does not have property $(name)")
-        @debug "Accessing private field :$(name) of Node"
         setfield!(node, name, x)
     end
 end


### PR DESCRIPTION
I think this can be super slow if it gets hit a ton and possibly could cause https://github.com/julia-actions/julia-docdeploy/issues/31

In general stacktraces are slow, but usually they are only being generated exceptionally. As part of logging they could be generated much more often.