### PR TITLE
Implement `Base.replace`/`Base.replace!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MarkdownAST.jl changelog
 
+## Unreleased
+
+* ![Feature][badge-feature] Implemented `replace` and `replace!` to safely mutate trees in arbitrary ways, and `empty!(node.children)` to remove all the children of a node
+
 ## Version `v0.1.1`
 
 * ![Bugfix][badge-bugfix] `append!` and `prepend!` methods now correctly append nodes from a `node.children` iterator. ([#16][github-16])

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MarkdownAST"
 uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
 authors = ["Morten Piibeleht <morten.piibeleht@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2-dev"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/node.md
+++ b/docs/src/node.md
@@ -45,9 +45,11 @@ Changing the structure of the tree in any other way should generally be avoided,
 !!! warning "Mutating the tree while traversing"
 
     Mutating the structure of the tree while traversing it with some iterator (e.g. `.children` or one of the [AbstractTrees iterators](@ref "Iteration over trees")) can lead to unexpected behavior and should generally be avoided.
-    Updating the `.element` of a node, on the other hand, is fine.
+    Updating the `.element` of a node while traversing, on the other hand, is fine. In general, [`replace!`](@ref) can be used to mutate a tree in arbitrary ways.
 
 ```@docs
+Base.replace(::Function, ::T) where {T <: Node}
+Base.replace!(::Function, ::Node)
 unlink!
 insert_before!
 insert_after!
@@ -55,6 +57,7 @@ Base.push!(::NodeChildren{T}, ::T) where {T <: Node}
 Base.pushfirst!(::NodeChildren{T}, ::T) where {T <: Node}
 Base.append!(::NodeChildren{T}, ::Any) where T
 Base.prepend!(::NodeChildren{T}, ::Any) where T
+Base.empty!(::NodeChildren)
 ```
 
 !!! note "Mutating the .children property"


### PR DESCRIPTION
This allows to safely mutate AST trees in arbitrary ways.

Also implements `empty!(node.children)`, which is used as part of `replace`.

Full tests and documentation are included.

Blocker for https://github.com/JuliaDocs/DocumenterCitations.jl/issues/6, https://github.com/JuliaDocs/DocumenterCitations.jl/issues/14, and https://github.com/JuliaDocs/DocumenterCitations.jl/issues/14

Closes #20 