### PR TITLE
Fix nightly CI with Base.invokelatest

### DIFF
--- a/test/basedocstrings.jl
+++ b/test/basedocstrings.jl
@@ -28,7 +28,7 @@ function allmodules()
     submodules = find_submodules(Base)
     for stdlib in list_stdlibs()
         Base.eval(@__MODULE__, :(import $stdlib))
-        m = getfield(@__MODULE__, stdlib)
+        m = Base.invokelatest(getfield, @__MODULE__, stdlib)
         find_submodules!(submodules, m)
     end
     return submodules
@@ -51,7 +51,7 @@ end
 function alldocstrings()
     mds = Markdown.MD[]
     for m in allmodules()
-        moduledocstrings!(mds, m)
+        Base.invokelatest(moduledocstrings!, mds, m)
     end
     return mds
 end

--- a/test/basedocstrings.jl
+++ b/test/basedocstrings.jl
@@ -28,7 +28,7 @@ function allmodules()
     submodules = find_submodules(Base)
     for stdlib in list_stdlibs()
         Base.eval(@__MODULE__, :(import $stdlib))
-        m = Base.invokelatest(getfield, @__MODULE__, stdlib)
+        m = getfield(@__MODULE__, stdlib)
         find_submodules!(submodules, m)
     end
     return submodules
@@ -51,7 +51,7 @@ end
 function alldocstrings()
     mds = Markdown.MD[]
     for m in allmodules()
-        Base.invokelatest(moduledocstrings!, mds, m)
+        moduledocstrings!(mds, m)
     end
     return mds
 end


### PR DESCRIPTION
Try to fix https://github.com/JuliaDocs/MarkdownAST.jl/actions/runs/16410813544/job/46365169763

Locally got this, and this seemed to make the suite run again:

```
$ julia +nightly --depwarn=error --project test/basedocstrings.jl

Base docstrings: Error During Test at /home/mortenpi/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:59
  Got exception outside of a @test
  MethodError: no method matching parsedoc(::Base.Docs.DocStr)
  The applicable method may be too new: running in world age 39031, while current world is 39081.
  Closest candidates are:
    parsedoc(::Base.Docs.DocStr) (method too new to be called from this world context.)
     @ REPL ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/REPL/src/docview.jl:89
  Stacktrace:
   [1] moduledocstrings!(mds::Vector{Markdown.MD}, m::Module)
     @ Main ~/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:41
   [2] alldocstrings
     @ ~/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:54 [inlined]
   [3] macro expansion
     @ ~/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:60 [inlined]
   [4] macro expansion
     @ ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:1858 [inlined]
   [5] top-level scope
     @ ~/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:60
   [6] include(mod::Module, _path::String)
     @ Base ./Base.jl:311
   [7] exec_options(opts::Base.JLOptions)
     @ Base ./client.jl:320
   [8] _start()
     @ Base ./client.jl:553
Test Summary:   | Error  Total  Time
Base docstrings |     1      1  3.3s
RNG of the outermost testset: Random.Xoshiro(0x1cf237dfcd1c7d78, 0x0bec09bb17ba56b9, 0x9657221558aa8ccd, 0x4609de770d52e38e, 0x1aaf14bd2ce47a86)
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /home/mortenpi/juliadocs/clones/MarkdownAST.jl/test/basedocstrings.jl:59
```
