### PR TITLE
Add Markdown.Strikethrough support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MarkdownAST.jl changelog
 
+## Version `Unreleased`
+
+* ![Feature][badge-feature] Added support for `Strikethrough` nodes when converting to/from the Markdown stdlib AST. This interop requires Julia 1.14+, because `Markdown.Strikethrough` is only available in the stdlib starting there. ([#31][github-31], [#32][github-32])
+
 ## Version `v0.1.2`
 
 * ![Feature][badge-feature] Implemented `replace` and `replace!` to safely mutate trees in arbitrary ways, and `empty!(node.children)` to remove all the children of a node. ([#22][github-22])
@@ -17,6 +21,8 @@ Initial release.
 [github-16]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/16
 [github-19]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/19
 [github-22]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/22
+[github-31]: https://github.com/JuliaDocs/MarkdownAST.jl/issues/31
+[github-32]: https://github.com/JuliaDocs/MarkdownAST.jl/pull/32
 <!-- end of issue link definitions -->
 
 [markdownast]: https://github.com/JuliaDocs/MarkdownAST.jl

--- a/docs/src/elements.md
+++ b/docs/src/elements.md
@@ -81,6 +81,7 @@ List
 Paragraph
 SoftBreak
 Strong
+Strikethrough
 Text
 ThematicBreak
 ```

--- a/src/markdown.jl
+++ b/src/markdown.jl
@@ -334,6 +334,14 @@ struct Strong <: AbstractInline end
 iscontainer(::Strong) = true
 
 """
+    struct Strikethrough <: AbstractInline
+
+Inline singleton element for strikethrough styling.
+"""
+struct Strikethrough <: AbstractInline end
+iscontainer(::Strikethrough) = true
+
+"""
     mutable struct Code <: AbstractInline
 
 Inline element representing an inline code span.

--- a/src/stdlib/fromstdlib.jl
+++ b/src/stdlib/fromstdlib.jl
@@ -134,6 +134,9 @@ end
 # Inline nodes:
 _convert_inline(nodefn::NodeFn, s::Markdown.Bold) = _convert(nodefn, Strong(), _convert_inline, s.text)
 _convert_inline(nodefn::NodeFn, s::Markdown.Italic) = _convert(nodefn, Emph(), _convert_inline, s.text)
+@static if isdefined(Markdown, :Strikethrough)
+    _convert_inline(nodefn::NodeFn, s::Markdown.Strikethrough) = _convert(nodefn, Strikethrough(), _convert_inline, s.text)
+end
 function _convert_inline(nodefn::NodeFn, s::Markdown.Link)
     # The Base Markdown parser does not parse the title part, so we just default that to
     # an empty string.

--- a/src/stdlib/tostdlib.jl
+++ b/src/stdlib/tostdlib.jl
@@ -41,6 +41,13 @@ _convert_element(::Node, e::InlineMath) = Markdown.LaTeX(e.math)
 _convert_element(::Node, e::JuliaValue) = e.ref
 _convert_element(n::Node, e::Link) = Markdown.Link(_convert_element.(n.children), e.destination)
 _convert_element(n::Node, ::Strong) = Markdown.Bold(_convert_element.(n.children))
+@static if isdefined(Markdown, :Strikethrough)
+    _convert_element(n::Node, ::Strikethrough) = Markdown.Strikethrough(_convert_element.(n.children))
+else
+    function _convert_element(::Node, ::Strikethrough)
+        error("Unable to convert Strikethrough to Markdown stdlib on this Julia version")
+    end
+end
 _convert_element(::Node, e::Text) = e.text
 # Lists
 _convert_element(n::Node, e::List) = Markdown.List(

--- a/test/fromstdlib.jl
+++ b/test/fromstdlib.jl
@@ -1,5 +1,5 @@
 using MarkdownAST: MarkdownAST, Node, @ast, Document,
-    Emph, Strong, InlineMath, Link, Code, Image,
+    Emph, Strong, Strikethrough, InlineMath, Link, Code, Image,
     Paragraph, Heading, CodeBlock, BlockQuote, DisplayMath, ThematicBreak,
     List, Item, FootnoteLink, FootnoteDefinition, Admonition,
     Table, TableHeader, TableBody, TableRow, TableCell,
@@ -46,6 +46,14 @@ using Test
             Link("url://", "") do; "bbb"; end
             " ccc "
             Image("url", "") do; "aaa"; end
+        end
+    end
+
+    @static if isdefined(Markdown, :Strikethrough)
+        @test convert(Node, Markdown.parse("~~xxx~~")) == @ast Document() do
+            Paragraph() do
+                Strikethrough() do; "xxx"; end
+            end
         end
     end
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -3,7 +3,7 @@ using MarkdownAST: AbstractElement, AbstractBlock, AbstractInline,
     Document,
     Admonition, BlockQuote, CodeBlock, DisplayMath, FootnoteDefinition, HTMLBlock, Heading,
     Item, List, Paragraph, ThematicBreak,
-    Code, Emph, FootnoteLink, HTMLInline, Image, InlineMath, Link, Strong, JuliaValue,
+    Code, Emph, FootnoteLink, HTMLInline, Image, InlineMath, Link, Strong, Strikethrough, JuliaValue,
     TableComponent, Table, TableHeader, TableBody, TableRow, TableCell,
     LineBreak, SoftBreak, Backslash,
     iscontainer, can_contain, isblock, isinline
@@ -87,7 +87,7 @@ MarkdownAST.iscontainer(e::PseudoInline) = e.iscontainer
     end
 
     # (4) Inlines containing inlines:
-    for e in [Link("url", "title"), Image("url", "title"), Emph(), Strong()]
+    for e in [Link("url", "title"), Image("url", "title"), Emph(), Strong(), Strikethrough()]
         @test iscontainer(e)
         @test ! isblock(e)
         @test isinline(e)

--- a/test/tostdlib.jl
+++ b/test/tostdlib.jl
@@ -1,5 +1,5 @@
 using MarkdownAST: MarkdownAST, Node, @ast, Document,
-    Emph, Strong, InlineMath, Link, Code, Image,
+    Emph, Strong, Strikethrough, InlineMath, Link, Code, Image,
     Paragraph, Heading, CodeBlock, BlockQuote, DisplayMath, ThematicBreak,
     List, Item, FootnoteLink, FootnoteDefinition, Admonition,
     Table, TableHeader, TableBody, TableRow, TableCell,
@@ -89,6 +89,22 @@ struct UnknownBlock <: MarkdownAST.AbstractBlock end
         end
         md = convert(Markdown.MD, ast)
         @test ast == convert(Node, md)
+    end
+
+    let ast = @ast Document() do
+            Paragraph() do
+                "pre "
+                Strikethrough() do; "mid"; end
+                " post"
+            end
+        end
+        if isdefined(Markdown, :Strikethrough)
+            md = convert(Markdown.MD, ast)
+            @test md.content[1].content[2] isa Markdown.Strikethrough
+            @test convert(Node, md) == ast
+        else
+            @test_throws ErrorException convert(Markdown.MD, ast)
+        end
     end
 
     # JuliaValue


### PR DESCRIPTION
To cope with changes in Julia 1.14, see <https://github.com/JuliaLang/julia/pull/60537>


Co-authored-by: Codex <codex@openai.com>
