### PR TITLE
Update CI, adjust to Julia nightly changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
-      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Run test/basedocstrings.jl
         run: julia --project --color=yes --code-coverage=all test/basedocstrings.jl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         julia-version: ['1.0', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          - os: macos-latest
+            version: '1.0'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
+      - uses: julia-actions/cache@v2
       - name: Instantiate docs/ environment
         run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,37 +7,45 @@ on:
       - release-*
     tags: '*'
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        julia-arch: [x64]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-runtest@v1
       - name: Run test/basedocstrings.jl
         run: julia --project --color=yes --code-coverage=all test/basedocstrings.jl
         if: matrix.julia-version != '1.0'
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   documentation:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - name: Instantiate docs/ environment

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
           - os: macos-latest
-            version: '1.0'
+            julia-version: '1.0'
 
     steps:
       - uses: actions/checkout@v6

--- a/test/basedocstrings.jl
+++ b/test/basedocstrings.jl
@@ -6,8 +6,8 @@ using Markdown, Pkg, Test
 
 function list_stdlibs()
     stdlibs = Symbol[]
-    for stdlib in readdir(Pkg.stdlib_dir())
-        stdlib_path = joinpath(Pkg.stdlib_dir(), stdlib)
+    for stdlib in readdir(Sys.STDLIB)
+        stdlib_path = joinpath(Sys.STDLIB, stdlib)
         isdir(stdlib_path) || continue
         endswith(stdlib, "_jll") && continue
         push!(stdlibs, Symbol(stdlib))

--- a/test/fromstdlib.jl
+++ b/test/fromstdlib.jl
@@ -126,6 +126,7 @@ using Test
 
     @test convert(Node, Markdown.md"""
     1. aaa
+
     2. bbb
 
     * aaa
@@ -133,7 +134,7 @@ using Test
       - ccc
     * ddd
     """) == @ast Document() do
-        List(:ordered, true) do
+        List(:ordered, false) do
             Item() do; Paragraph() do; "aaa"; end; end
             Item() do; Paragraph() do; "bbb"; end; end
         end
@@ -267,13 +268,22 @@ using Test
         end
     end
     # This would lead to a SoftBreak() in CommonMark, but not in Markdown
-    @test convert(Node, Markdown.md"""
-    foo
-    bar
-    """) == @ast Document() do
-        Paragraph() do
-            "foo bar"
-        end
+    let ast = convert(Node, Markdown.md"""
+        foo
+        bar
+        """)
+        @test ast in (
+            @ast(Document() do
+                Paragraph() do
+                    "foo bar"  # In Julia 1.14, whitespaces are "normalized"
+                end
+            end),
+            @ast(Document() do
+                Paragraph() do
+                    "foo\nbar"  # In Julia 1.14, the newline is preserved
+                end
+            end),
+        )
     end
 
     # Interpolation
@@ -343,13 +353,21 @@ using Test
     end
 
     # Tests from the Documenter Markdown2 module
-    @test convert(Node, Markdown.parse(raw"""
-    $$
-    f
-    $$
-    """)) == @ast Document() do
-        Paragraph() do; JuliaValue(nothing, :$); end
-        Paragraph() do; "f "; JuliaValue(nothing, :$); end
+    let ast = convert(Node, Markdown.parse(raw"""
+        $$
+        f
+        $$
+        """))
+        @test ast in (
+            @ast(Document() do
+                Paragraph() do; JuliaValue(nothing, :$); end
+                Paragraph() do; "f "; JuliaValue(nothing, :$); end # Julia <= 1.13
+            end),
+            @ast(Document() do
+                Paragraph() do; JuliaValue(nothing, :$); end
+                Paragraph() do; "f\n"; JuliaValue(nothing, :$); end # Julia >= 1.14
+            end),
+        )
     end
     @test convert(Node, Markdown.parse(raw"""
     X $(42) Y

--- a/test/fromstdlib.jl
+++ b/test/fromstdlib.jl
@@ -329,7 +329,7 @@ using Test
     # It is theoretically possible to have inline nodes in block context:
     let m = Markdown.MD()
         push!(m.content, "Foo")
-        push!(m.content, Markdown.Link("text", "url"))
+        push!(m.content, Markdown.Link(["text"], "url"))
         @test convert(Node, m) == @ast Document() do
             Paragraph() do
                 "Foo"


### PR DESCRIPTION
Drop `julia-actions/julia-buildpkg` (we don't need it), update some other actions; don't specify an arch(itecture) that is wrong for macOS runners; better concurrency handling...