### PR TITLE
Add Markdown.HTMLInline stdlib conversion support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version `Unreleased`
 
 * ![Feature][badge-feature] Added support for converting `HTMLBlock` nodes to and from `Markdown.HTMLBlock` when using Julia 1.14+, where the corresponding stdlib type is available.
+* ![Feature][badge-feature] Added support for converting `HTMLInline` nodes to and from `Markdown.HTMLInline` when using Julia 1.14+, where the corresponding stdlib type is available.
 * ![Feature][badge-feature] Added support for `Strikethrough` nodes when converting to/from the Markdown stdlib AST. This interop requires Julia 1.14+, because `Markdown.Strikethrough` is only available in the stdlib starting there. ([#31][github-31], [#32][github-32])
 
 ## Version `v0.1.2`

--- a/docs/src/stdlib.md
+++ b/docs/src/stdlib.md
@@ -29,6 +29,7 @@ Due to the differences between the Markdown representations, the following thing
 - When converting a `Markdown.Table`, the resulting table will be normalized, such as adding empty cells to rows, to make sure that all rows have the same number of cells.
 - For links and images, the `.title` attribute is set to an empty string, since the standard library AST does not support parsing titles.
 - On Julia 1.14 and newer, `Markdown.HTMLBlock` values are converted to [`HTMLBlock`](@ref) elements. On older Julia versions, such nodes do not exist in the standard library AST.
+- On Julia 1.14 and newer, `Markdown.HTMLInline` values are converted to [`HTMLInline`](@ref) elements. On older Julia versions, such nodes do not exist in the standard library AST.
 
 ## Conversion to standard library representation
 
@@ -47,6 +48,7 @@ Due to the differences between the Markdown representations, the following thing
 - The standard library does not support storing the child nodes of [`Image`](@ref) elements (i.e. "alt text", `![alt text]()`) as AST, and it is instead reduced to a string with the help of the `Markdown.plain` function.
 - The standard library AST does not have dedicated elements for [`SoftBreak`](@ref) and [`Backslash`](@ref), and these get converted into strings (i.e. text elements) instead.
 - On Julia 1.14 and newer, [`HTMLBlock`](@ref) elements are converted into `Markdown.HTMLBlock`. On older Julia versions they are converted into `Markdown.Code("html", ...)`.
+- On Julia 1.14 and newer, [`HTMLInline`](@ref) elements are converted into `Markdown.HTMLInline`. On older Julia versions they are converted into `Markdown.Code("", ...)`.
 
 ## Index
 

--- a/src/stdlib/fromstdlib.jl
+++ b/src/stdlib/fromstdlib.jl
@@ -166,6 +166,9 @@ _convert_inline(nodefn::NodeFn, s::Markdown.Image) = @ast Image(s.url, "") do
     s.alt # TODO: if isempty(s.alt), should be just omit adding children here?
 end
 _convert_inline(nodefn::NodeFn, ::Markdown.LineBreak) = nodefn(LineBreak())
+@static if isdefined(Markdown, :HTMLInline)
+    _convert_inline(nodefn::NodeFn, s::Markdown.HTMLInline) = nodefn(HTMLInline(s.content))
+end
 # Non-Commonmark extensions
 _convert_inline(nodefn::NodeFn, s::Markdown.LaTeX) = nodefn(InlineMath(s.formula))
 function _convert_inline(nodefn::NodeFn, s::Markdown.Footnote)

--- a/src/stdlib/tostdlib.jl
+++ b/src/stdlib/tostdlib.jl
@@ -78,4 +78,8 @@ _convert_element(n::Node, ::Backslash) = "\\"
 else
     _convert_element(::Node, e::HTMLBlock) = Markdown.Code("html", e.html)
 end
-_convert_element(::Node, e::HTMLInline) = Markdown.Code("", e.html)
+@static if isdefined(Markdown, :HTMLInline)
+    _convert_element(::Node, e::HTMLInline) = Markdown.HTMLInline(e.html)
+else
+    _convert_element(::Node, e::HTMLInline) = Markdown.Code("", e.html)
+end

--- a/test/fromstdlib.jl
+++ b/test/fromstdlib.jl
@@ -3,7 +3,7 @@ using MarkdownAST: MarkdownAST, Node, @ast, Document,
     Paragraph, Heading, CodeBlock, BlockQuote, DisplayMath, ThematicBreak,
     List, Item, FootnoteLink, FootnoteDefinition, Admonition,
     Table, TableHeader, TableBody, TableRow, TableCell,
-    JuliaValue, LineBreak, HTMLBlock
+    JuliaValue, LineBreak, HTMLBlock, HTMLInline
 using Markdown: Markdown
 using Test
 
@@ -364,6 +364,16 @@ using Test
             push!(m.content, Markdown.HTMLBlock(["<div>", "x", "</div>"]))
             @test convert(Node, m) == @ast Document() do
                 HTMLBlock("<div>\nx\n</div>")
+            end
+        end
+    end
+    @static if isdefined(Markdown, :HTMLInline)
+        let m = Markdown.MD()
+            push!(m.content, Markdown.Paragraph([Markdown.HTMLInline("<span>x</span>")]))
+            @test convert(Node, m) == @ast Document() do
+                Paragraph() do
+                    HTMLInline("<span>x</span>")
+                end
             end
         end
     end


### PR DESCRIPTION
To cope with changes in Julia 1.14, see <https://github.com/JuliaLang/julia/pull/60732>

Co-authored-by: Codex <codex@openai.com>